### PR TITLE
Fixed relativity of download path arg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="gli99",
-    version='1.1.6',
+    version='1.1.7',
     description="Web scraper for gifcities.org",
     package_dir={'':'src'},
     packages=setuptools.find_packages(where="src"),

--- a/src/gli99/tools.py
+++ b/src/gli99/tools.py
@@ -29,9 +29,11 @@ class GifScraper():
         self.browser=browser
         self.sources = []
         self.options = None
-        abspath = os.path.abspath(__file__)
-        dname = os.path.dirname(abspath)
-        os.chdir(dname)
+        
+	abspath = os.path.abspath(__file__)
+        root = os.path.dirname(abspath)
+        options_path = os.path.normpath(root + "/browser_options.json")
+
         options_json = json.load(open('browser_options.json','r'))
         
         print(f"attempting to create {browser} driver ",end="... ")


### PR DESCRIPTION
An unpaired `os.chdir()` is used and makes `gs.download()` calls relative to the site package directory as opposed to the executed process' cwd: 
https://github.com/TomTkacz/gli99/blob/5b7e8760912ef7fd2a11ccabdca9cfc114258df6/src/gli99/tools.py#L32-L35
swapped the `os.chdir(dname)` with `options_path = os.path.normpath(root + "/browser_options.json")` to handle platform-specific path separators and to have `gs.download()` handle both relative and absolute path args as expected